### PR TITLE
Prefer route configuration over automatic `explicit` detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#10](https://github.com/mezzio/mezzio-cors/pull/10) Per-route `explicit` configuration is now properly handled.
+
 - [#13](https://github.com/mezzio/mezzio-cors/pull/13) Added missing default value for `allowed_max_age` which fixes [#12](https://github.com/mezzio/mezzio-cors/issues/12)
 
 ## 1.0.1 - 2020-09-02

--- a/src/Service/ConfigurationLocator.php
+++ b/src/Service/ConfigurationLocator.php
@@ -100,7 +100,7 @@ final class ConfigurationLocator implements ConfigurationLocatorInterface
                 ->withRequestMethods($allowedMethods);
         }
 
-        $routeParameters = ['explicit' => $explicit] + $routeParameters;
+        $routeParameters = $routeParameters + ['explicit' => $explicit];
 
         $routeConfiguration = $routeConfigurationFactory($routeParameters)
             ->withRequestMethods($allowedMethods);

--- a/src/Service/ConfigurationLocator.php
+++ b/src/Service/ConfigurationLocator.php
@@ -100,7 +100,7 @@ final class ConfigurationLocator implements ConfigurationLocatorInterface
                 ->withRequestMethods($allowedMethods);
         }
 
-        $routeParameters = $routeParameters + ['explicit' => $explicit];
+        $routeParameters += ['explicit' => $explicit];
 
         $routeConfiguration = $routeConfigurationFactory($routeParameters)
             ->withRequestMethods($allowedMethods);

--- a/test/Service/ConfigurationLocatorTest.php
+++ b/test/Service/ConfigurationLocatorTest.php
@@ -357,9 +357,11 @@ final class ConfigurationLocatorTest extends TestCase
             ->method('isFailure')
             ->willReturn(false);
 
-        $routeConfigurationParameters = [RouteConfigurationInterface::PARAMETER_IDENTIFIER => [
-            'explicit' => true,
-        ]];
+        $routeConfigurationParameters = [
+            RouteConfigurationInterface::PARAMETER_IDENTIFIER => [
+                'explicit' => true,
+            ],
+        ];
 
         $matchingExplicitRouteResult
             ->expects($this->once())

--- a/test/Service/ConfigurationLocatorTest.php
+++ b/test/Service/ConfigurationLocatorTest.php
@@ -357,10 +357,14 @@ final class ConfigurationLocatorTest extends TestCase
             ->method('isFailure')
             ->willReturn(false);
 
+        $routeConfigurationParameters = [RouteConfigurationInterface::PARAMETER_IDENTIFIER => [
+            'explicit' => true,
+        ]];
+
         $matchingExplicitRouteResult
             ->expects($this->once())
             ->method('getMatchedParams')
-            ->willReturn([RouteConfigurationInterface::PARAMETER_IDENTIFIER => []]);
+            ->willReturn($routeConfigurationParameters);
 
         $matchingExplicitRouteResult
             ->expects($this->once())
@@ -382,6 +386,7 @@ final class ConfigurationLocatorTest extends TestCase
         $this->routeConfigurationFactory
             ->expects($this->any())
             ->method('__invoke')
+            ->withConsecutive([], $routeConfigurationParameters)
             ->willReturn($routeConfiguration);
 
         $routeConfiguration


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

The route configuration of `explicit` was ignored due to an invalid ordering of the array combination syntax `+`.

Closes #9 