### PR TITLE
bugfix: ensure non-empty string default for allowedMaxAge configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#13](https://github.com/mezzio/mezzio-cors/pull/13) Added missing default value for `allowed_max_age` which fixes [#12](https://github.com/mezzio/mezzio-cors/issues/12)
 
 ## 1.0.1 - 2020-09-02
 

--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -37,7 +37,7 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     protected $allowedHeaders = [];
 
     /** @var string */
-    protected $allowedMaxAge = '';
+    protected $allowedMaxAge = ConfigurationInterface::PREFLIGHT_CACHE_DISABLED;
 
     /** @var bool */
     protected $credentialsAllowed = false;

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -11,6 +11,7 @@ interface ConfigurationInterface
      */
     public const CONFIGURATION_IDENTIFIER = 'expressive.cors';
     public const ANY_ORIGIN               = '*';
+    public const PREFLIGHT_CACHE_DISABLED = '-1';
 
     /**
      * Should return all allowed methods, the requested path can handle.
@@ -27,7 +28,7 @@ interface ConfigurationInterface
     public function allowedHeaders(): array;
 
     /**
-     * Should return the maximum age, the response may be cached by a client.
+     * Should return the maximum age, the preflight response may be cached by a client.
      */
     public function allowedMaxAge(): string;
 

--- a/src/Configuration/RouteConfiguration.php
+++ b/src/Configuration/RouteConfiguration.php
@@ -62,7 +62,7 @@ final class RouteConfiguration extends AbstractConfiguration implements RouteCon
             $instance->setCredentialsAllowed($configuration->credentialsAllowed());
         }
 
-        if (! $instance->allowedMaxAge()) {
+        if ($instance->allowedMaxAge() === ConfigurationInterface::PREFLIGHT_CACHE_DISABLED) {
             $instance->setAllowedMaxAge($configuration->allowedMaxAge());
         }
 

--- a/test/Configuration/ProjectConfigurationTest.php
+++ b/test/Configuration/ProjectConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\CorsTest\Configuration;
 
+use Mezzio\Cors\Configuration\ConfigurationInterface;
 use Mezzio\Cors\Configuration\Exception\InvalidConfigurationException;
 use Mezzio\Cors\Configuration\ProjectConfiguration;
 use PHPUnit\Framework\TestCase;
@@ -58,6 +59,17 @@ final class ProjectConfigurationTest extends TestCase
     public function testWillDisablePreflightCacheWhenAllowedMaxAgeIsNotConfigured(): void
     {
         $config = new ProjectConfiguration([]);
-        $this->assertSame('-1', $config->allowedMaxAge());
+        $this->assertSame(ConfigurationInterface::PREFLIGHT_CACHE_DISABLED, $config->allowedMaxAge());
+    }
+
+    public function testWillInstantiateProjectConfiguration(): void
+    {
+        $instance = new ProjectConfiguration([]);
+        self::assertEquals(ConfigurationInterface::PREFLIGHT_CACHE_DISABLED, $instance->allowedMaxAge());
+        self::assertEmpty($instance->allowedMethods());
+        self::assertEmpty($instance->allowedOrigins());
+        self::assertEmpty($instance->allowedHeaders());
+        self::assertEmpty($instance->exposedHeaders());
+        self::assertFalse($instance->credentialsAllowed());
     }
 }

--- a/test/Configuration/ProjectConfigurationTest.php
+++ b/test/Configuration/ProjectConfigurationTest.php
@@ -54,4 +54,10 @@ final class ProjectConfigurationTest extends TestCase
         $this->expectException(InvalidConfigurationException::class);
         new ProjectConfiguration(['foo' => 'bar']);
     }
+
+    public function testWillDisablePreflightCacheWhenAllowedMaxAgeIsNotConfigured(): void
+    {
+        $config = new ProjectConfiguration([]);
+        $this->assertSame('-1', $config->allowedMaxAge());
+    }
 }

--- a/test/Configuration/RouteConfigurationFactoryTest.php
+++ b/test/Configuration/RouteConfigurationFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\CorsTest\Configuration;
 
+use Mezzio\Cors\Configuration\ConfigurationInterface;
 use Mezzio\Cors\Configuration\RouteConfigurationFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +25,7 @@ final class RouteConfigurationFactoryTest extends TestCase
     {
         $factory  = $this->factory;
         $instance = $factory([]);
-        self::assertEmpty($instance->allowedMaxAge());
+        self::assertEquals(ConfigurationInterface::PREFLIGHT_CACHE_DISABLED, $instance->allowedMaxAge());
         self::assertEmpty($instance->allowedMethods());
         self::assertEmpty($instance->allowedOrigins());
         self::assertEmpty($instance->allowedHeaders());

--- a/test/Configuration/RouteConfigurationTest.php
+++ b/test/Configuration/RouteConfigurationTest.php
@@ -174,4 +174,10 @@ final class RouteConfigurationTest extends TestCase
 
         $this->assertSame($routeConfiguration, $routeConfiguration);
     }
+
+    public function testWillDisablePreflightCacheWhenAllowedMaxAgeIsNotConfigured(): void
+    {
+        $config = new ProjectConfiguration([]);
+        $this->assertSame('-1', $config->allowedMaxAge());
+    }
 }

--- a/test/Configuration/RouteConfigurationTest.php
+++ b/test/Configuration/RouteConfigurationTest.php
@@ -178,6 +178,6 @@ final class RouteConfigurationTest extends TestCase
     public function testWillDisablePreflightCacheWhenAllowedMaxAgeIsNotConfigured(): void
     {
         $config = new ProjectConfiguration([]);
-        $this->assertSame('-1', $config->allowedMaxAge());
+        $this->assertSame(ConfigurationInterface::PREFLIGHT_CACHE_DISABLED, $config->allowedMaxAge());
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

This PR should fix #12 as there was no default value for the `allowed_max_age` configuration.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
