### PR TITLE
Fixed typo in docs where wrong headers are referenced

### DIFF
--- a/docs/book/v1/middleware.md
+++ b/docs/book/v1/middleware.md
@@ -37,9 +37,9 @@ On the project level, you can only configure the following Headers:
 |:-------------|:-------------:|:-----:
 | `allowed_origins` | string[] | Access-Control-Allow-Origin
 | `allowed_headers` | string[] | Access-Control-Allow-Headers
-| `allowed_max_age` | string (TTL in seconds) | Access-Control-Allowed-Max-Age
+| `allowed_max_age` | string (TTL in seconds) | Access-Control-Max-Age
 | `credentials_allowed` | bool | Access-Control-Allow-Credentials
-| `exposed_headers` | string[] | Access-Control-Exposed-Headers
+| `exposed_headers` | string[] | Access-Control-Expose-Headers
 
 On the route level, you can configure all of the projects configuration settings
 and if the configuration of the route should either override the project
@@ -52,9 +52,9 @@ configuration (default) or merge it.
 | `explicit` | bool | -
 | `allowed_origins` | string[] | Access-Control-Allow-Origin
 | `allowed_headers` | string[] | Access-Control-Allow-Headers
-| `allowed_max_age` | string (TTL in seconds) | Access-Control-Allowed-Max-Age
+| `allowed_max_age` | string (TTL in seconds) | Access-Control-Max-Age
 | `credentials_allowed` | bool | Access-Control-Allow-Credentials
-| `exposed_headers` | string[] | Access-Control-Exposed-Headers
+| `exposed_headers` | string[] | Access-Control-Expose-Headers
 
 The parameter `overrides_project_configuration` handles the way how the
 configuration is being merged. The default setting is `true` to ensure that a


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | kind of
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This fixes a typo in the docs, where the `Access-Control-Allowed-Max-Age` and `Access-Control-Exposed-Headers` headers are referenced, where it should be `Access-Control-Max-Age` and `Access-Control-Expose-Headers`.

It's just a typo in the docs, the code is using the proper values.

> This is the same as https://github.com/mezzio/mezzio-cors/pull/15, but pointing to the proper branch