### PR TITLE
Bugfix/serverparams

### DIFF
--- a/src/Service/ConfigurationLocator.php
+++ b/src/Service/ConfigurationLocator.php
@@ -59,7 +59,7 @@ final class ConfigurationLocator implements ConfigurationLocatorInterface
 
         $anyRouteIsMatching = false;
         foreach ($requestMethods as $method) {
-            $request = $this->requestFactory->createServerRequest($method, $metadata->requestedUri);
+            $request = $this->requestFactory->createServerRequest($method, $metadata->requestedUri, $_SERVER);
             $route   = $this->router->match($request);
             if ($route->isFailure()) {
                 continue;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I had a very confusing bug while using Mezzio in the backend to provide data to an Vue.Js app. 

When calling a GET endpoint (`/swiftlog/get/:userId/`) in the browser, everything works as expected. When doing the same with axios (in Vue), Mezzio runs into the `NotFoundHandler` (404).

The reason is that `PHP_SELF` and everything else from `$_SERVER` is not set the `Parameters` object in `vendor/laminas/laminas-http/src/PhpEnvironment/Request.php` and therefore, `$baseurl` is empty.

The Mezzio backend runs on vagrant machine (`xxx.xx.xx.x/public/index.php/swiftlog/get/1/` mounted at the root level of the Mezzio project, the Vue app runs locally on my MacBook.

Adding `$_SERVER` to the `ConfigurationLocator` fixed the issue for me.

I hope the fix is valid and I have provided enough information to reproduce as the issue was required a deep dive into the source code. Please let me know if you need more information.

**EDIT:** I did accidentally a second commit for sign-offs instead of amending the commit message. What can I do?