### PR TITLE
Normalize accidentally widened php constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.4 || ^8.0 || ~8.1.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
         "fig/http-message-util": "^1.1",
         "mezzio/mezzio-router": "^3.1",
         "psr/container": "^1.0 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "151c8e7d26e07e317c34ee028d079ef4",
+    "content-hash": "7c447975b02fb04f907e3bb7155ee95a",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -4492,7 +4492,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0 || ~8.1.0"
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This component was released with an accidentally widened PHP constraint back in August 2020 due to myself introducing PHP 8.0 support.
With PHP 8.1, I also added `~8.1.0` (which was unnecessary at this point, I have no idea why I didn't realized it back then...) as in laminas/mezzio/laminas-api-tools components, we do use more strict PHP constraints to avoid surprises with new PHP releases.

As of now, this component would be installable on PHP 8.2 while it was never tested with that version. Since we do not want to provide implicit support for PHP 8.2, changing the PHP constraint to `~7.4.0 || ~8.0.0 || ~8.1.0` will do the trick.

Closes #45 