### PR TITLE
Handle invalid `Origin` header values in `CorsMiddleware`

### DIFF
--- a/src/Exception/InvalidOriginValueException.php
+++ b/src/Exception/InvalidOriginValueException.php
@@ -11,13 +11,16 @@ use function sprintf;
 
 final class InvalidOriginValueException extends RuntimeException implements ExceptionInterface
 {
-    private function __construct(string $message, ?Throwable $previous = null)
-    {
+    private function __construct(
+        string $message,
+        public readonly string $origin,
+        ?Throwable $previous = null
+    ) {
         parent::__construct($message, 0, $previous);
     }
 
     public static function fromThrowable(string $origin, Throwable $throwable): self
     {
-        return new self(sprintf('Provided Origin "%s" is invalid.', $origin), $throwable);
+        return new self(sprintf('Provided Origin "%s" is invalid.', $origin), $origin, $throwable);
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->


For requests with invalid `Origin` URIs (i.e. when using `laminas/laminas-diactoros`, passing `chrome-extension://asdkjasdkjasjkdasjkd` will throw `InvalidOriginValueException`), the `CorsMiddleware` is throwing an unhandled exception, which ends up in HTTP 500 in mezzio applications (unless the error is catched in the error handler and whyever some1 would then return a different HTTP status code).

So to properly handle this (as it some PSR-7 implementations do allow **any** scheme), I've created https://github.com/laminas/laminas-diactoros/issues/179.
However, after some feedback and more research, I found out that PSR-7 is actually quite "clear" on what MUST be supported and what MAY be supported:

> Implementations MUST support the schemes "http" and "https" case insensitively, and MAY accommodate other schemes if required.

It also states that unsupported schemes may end up in an `InvalidArgumentException`:

```php
/**
 * Return an instance with the specified scheme.
 *
 * This method MUST retain the state of the current instance, and return
 * an instance that contains the specified scheme.
 *
 * Implementations MUST support the schemes "http" and "https" case
 * insensitively, and MAY accommodate other schemes if required.
 *
 * An empty scheme is equivalent to removing the scheme.
 *
 * @param string $scheme The scheme to use with the new instance.
 * @return static A new instance with the specified scheme.
 * @throws \InvalidArgumentException for invalid or unsupported schemes.
 */
public function withScheme(string $scheme): UriInterface;
```

----

So as a conclusion, I decided to handle these problems in `mezzio-cors` since `InvalidOriginValueException` may also occur for other issues unrelated to the `scheme`. 

So this patch handles `InvalidOriginValueException` in `CorsMiddleware` when passing the request to `CorsInterface#isCorsRequest` and returns an unauthorized response now.
Prior this patch, an unhandled exception (`InvalidOriginValueException`) was bubbling up the middleware pipeline in `mezzio` applications and thus, this change might not introduce a real BC break, WDYT?

I am targeting the next minor as I also introduced a way to actually fetch the RAW `Origin` header value from the `InvalidOriginValueException` so that consumers of the `CorsInterface` can access the header value (so does `CorsMiddleware`).
