### PR TITLE
Fix missing allowed_methods support

### DIFF
--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -6,6 +6,7 @@ namespace Mezzio\Cors\Configuration;
 
 use Mezzio\Cors\Configuration\Exception\InvalidConfigurationException;
 use Mezzio\Cors\Exception\BadMethodCallException;
+use Mezzio\Cors\Service\CorsMetadata;
 use Webmozart\Assert\Assert;
 
 use function array_unique;
@@ -14,10 +15,14 @@ use function call_user_func;
 use function in_array;
 use function is_callable;
 use function lcfirst;
+use function sort;
 use function sprintf;
 use function str_replace;
 use function ucfirst;
 use function ucwords;
+
+use const SORT_ASC;
+use const SORT_STRING;
 
 abstract class AbstractConfiguration implements ConfigurationInterface
 {
@@ -137,6 +142,19 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     {
         Assert::allString($headers);
         $this->exposedHeaders = array_values(array_unique($headers));
+    }
+
+    /**
+     * @psalm-param list<string> $methods
+     */
+    public function setAllowedMethods(array $methods): void
+    {
+        Assert::allOneOf($methods, CorsMetadata::ALLOWED_REQUEST_METHODS);
+
+        $methods = array_values(array_unique($methods));
+        sort($methods, SORT_ASC | SORT_STRING);
+
+        $this->allowedMethods = $methods;
     }
 
     public function exposedHeaders(): array

--- a/src/Configuration/RouteConfiguration.php
+++ b/src/Configuration/RouteConfiguration.php
@@ -4,15 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Cors\Configuration;
 
-use Mezzio\Cors\Service\CorsMetadata;
-use Webmozart\Assert\Assert;
-
-use function array_unique;
-use function sort;
-
-use const SORT_ASC;
-use const SORT_STRING;
-
 final class RouteConfiguration extends AbstractConfiguration implements RouteConfigurationInterface
 {
     private bool $overridesProjectConfiguration = true;
@@ -65,8 +56,9 @@ final class RouteConfiguration extends AbstractConfiguration implements RouteCon
         $instance->setAllowedHeaders([...$configuration->allowedHeaders(), ...$instance->allowedHeaders()]);
         $instance->setAllowedOrigins([...$configuration->allowedOrigins(), ...$instance->allowedOrigins()]);
         $instance->setExposedHeaders([...$configuration->exposedHeaders(), ...$instance->exposedHeaders()]);
+        $instance->setAllowedMethods([...$configuration->allowedMethods(), ...$instance->allowedMethods()]);
 
-        return $instance->withRequestMethods($configuration->allowedMethods());
+        return $instance;
     }
 
     /**
@@ -76,25 +68,9 @@ final class RouteConfiguration extends AbstractConfiguration implements RouteCon
      */
     public function withRequestMethods(array $methods): RouteConfigurationInterface
     {
-        $methods = $this->normalizeRequestMethods([...$this->allowedMethods, ...$methods]);
-
-        $instance                 = clone $this;
-        $instance->allowedMethods = $methods;
+        $instance = clone $this;
+        $instance->setAllowedMethods([...$this->allowedMethods, ...$methods]);
 
         return $instance;
-    }
-
-    /**
-     * @param array<int|string,string> $methods
-     * @psalm-return list<string>
-     */
-    private function normalizeRequestMethods(array $methods): array
-    {
-        Assert::allOneOf($methods, CorsMetadata::ALLOWED_REQUEST_METHODS);
-
-        $methods = array_unique($methods);
-        sort($methods, SORT_ASC | SORT_STRING);
-
-        return $methods;
     }
 }

--- a/test/Configuration/ProjectConfigurationTest.php
+++ b/test/Configuration/ProjectConfigurationTest.php
@@ -20,6 +20,7 @@ final class ProjectConfigurationTest extends TestCase
         $parameters = [
             'allowed_origins'     => ['foo'],
             'allowed_headers'     => ['baz'],
+            'allowed_methods'     => ['GET'],
             'allowed_max_age'     => '123',
             'credentials_allowed' => true,
             'exposed_headers'     => ['foo', 'bar', 'baz'],
@@ -28,6 +29,7 @@ final class ProjectConfigurationTest extends TestCase
 
         $this->assertSame(['foo'], $config->allowedOrigins());
         $this->assertSame(['baz'], $config->allowedHeaders());
+        $this->assertSame(['GET'], $config->allowedMethods());
         $this->assertSame('123', $config->allowedMaxAge());
         $this->assertTrue($config->credentialsAllowed());
         $this->assertSame(['foo', 'bar', 'baz'], $config->exposedHeaders());
@@ -45,6 +47,7 @@ final class ProjectConfigurationTest extends TestCase
         $config = new ProjectConfiguration($camelCasedParameters);
         $this->assertSame(['foo'], $config->allowedOrigins());
         $this->assertSame(['baz'], $config->allowedHeaders());
+        $this->assertSame(['GET'], $config->allowedMethods());
         $this->assertSame('123', $config->allowedMaxAge());
         $this->assertTrue($config->credentialsAllowed());
         $this->assertSame(['foo', 'bar', 'baz'], $config->exposedHeaders());

--- a/test/Configuration/RouteConfigurationTest.php
+++ b/test/Configuration/RouteConfigurationTest.php
@@ -20,6 +20,7 @@ final class RouteConfigurationTest extends TestCase
         $parameters = [
             'overrides_project_configuration' => false,
             'allowed_origins'                 => ['foo'],
+            'allowed_methods'                 => ['GET'],
             'allowed_headers'                 => ['baz'],
             'allowed_max_age'                 => '123',
             'credentials_allowed'             => true,
@@ -29,7 +30,7 @@ final class RouteConfigurationTest extends TestCase
 
         $this->assertFalse($config->overridesProjectConfiguration());
         $this->assertSame(['foo'], $config->allowedOrigins());
-        $this->assertSame([], $config->allowedMethods());
+        $this->assertSame(['GET'], $config->allowedMethods());
         $this->assertSame(['baz'], $config->allowedHeaders());
         $this->assertSame('123', $config->allowedMaxAge());
         $this->assertTrue($config->credentialsAllowed());


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Following documentation, `allowed_methods` property doesn't work because missing setter method.